### PR TITLE
fix: ignore cypress tests workflow on changelog updates

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,10 @@
 name: cypress tests
-on: [push]
+
+on:
+  push:
+    branches-ignore:
+      - 'release-please-**'
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes a bug where the cypress workflow would run on release-please PRs.

closes #37 