### PR TITLE
fix: style use padding instead of margin analytics view for prevent scrolling

### DIFF
--- a/src/modules/views/analytics/GeneralStatistics.tsx
+++ b/src/modules/views/analytics/GeneralStatistics.tsx
@@ -42,7 +42,7 @@ const GeneralStatistics = ({ generalStatistics }: Props): JSX.Element => {
   );
 
   return (
-    <Box marginY={4}>
+    <Box paddingY={4}>
       <Typography variant="h6" align="center">
         {t('General Statistics')}
       </Typography>


### PR DESCRIPTION
closes #204 